### PR TITLE
feat: Gauntlet func now takes a context

### DIFF
--- a/certificate.go
+++ b/certificate.go
@@ -55,7 +55,7 @@ func NewCertificate(cert *x509.Certificate) (*Certificate, error) {
 	if cert.SignatureAlgorithm != SignatureAlgorithm {
 		return nil, fmt.Errorf(
 			"%w, unsupported signature algorithm '%s'",
-			ErrCertificateRequestInvalid,
+			ErrRequestInvalid,
 			cert.SignatureAlgorithm,
 		)
 	}
@@ -154,7 +154,7 @@ type CertificateRequest struct {
 func ParseCertificateRequest(asn1Data []byte) (*CertificateRequest, error) {
 	csr, err := x509.ParseCertificateRequest(asn1Data)
 	if err != nil {
-		return nil, fmt.Errorf("%w, %s", ErrCertificateRequestInvalid, err.Error())
+		return nil, fmt.Errorf("%w, %s", ErrRequestInvalid, err.Error())
 	}
 	return NewCertificateRequest(csr)
 }
@@ -167,7 +167,7 @@ func NewCertificateRequest(cert *x509.CertificateRequest) (*CertificateRequest, 
 	if cert.SignatureAlgorithm != SignatureAlgorithm {
 		return nil, fmt.Errorf(
 			"%w, unsupported signature algorithm '%s'",
-			ErrCertificateRequestInvalid,
+			ErrRequestInvalid,
 			cert.SignatureAlgorithm,
 		)
 	}
@@ -176,7 +176,7 @@ func NewCertificateRequest(cert *x509.CertificateRequest) (*CertificateRequest, 
 	if len(cert.Subject.Organization) != 1 {
 		return nil, fmt.Errorf(
 			"%w, missing identity namespace",
-			ErrCertificateRequestInvalid,
+			ErrRequestInvalid,
 		)
 	}
 	rawNS := cert.Subject.Organization[0]
@@ -184,7 +184,7 @@ func NewCertificateRequest(cert *x509.CertificateRequest) (*CertificateRequest, 
 	if err != nil {
 		return nil, fmt.Errorf(
 			"%w, invalid identity namespace %s: %w",
-			ErrCertificateRequestInvalid,
+			ErrRequestInvalid,
 			rawNS,
 			err,
 		)
@@ -194,7 +194,7 @@ func NewCertificateRequest(cert *x509.CertificateRequest) (*CertificateRequest, 
 	if !ok {
 		return nil, fmt.Errorf(
 			"%w, invalid public key type: '%T'",
-			ErrCertificateRequestInvalid,
+			ErrRequestInvalid,
 			cert.PublicKey,
 		)
 	}
@@ -208,10 +208,10 @@ func NewCertificateRequest(cert *x509.CertificateRequest) (*CertificateRequest, 
 	cid, err := uuid.Parse(cert.Subject.CommonName)
 	if err != nil {
 		return nil, fmt.Errorf("%w, invalid identity '%s', %s",
-			ErrCertificateRequestInvalid, cert.Subject.CommonName, err.Error())
+			ErrRequestInvalid, cert.Subject.CommonName, err.Error())
 	}
 	if cid != id {
-		return nil, fmt.Errorf("%w, incorrect identity", ErrCertificateRequestInvalid)
+		return nil, fmt.Errorf("%w, incorrect identity", ErrRequestInvalid)
 	}
 
 	bfReq := &CertificateRequest{

--- a/cmd/bf/proxy.go
+++ b/cmd/bf/proxy.go
@@ -168,7 +168,7 @@ func issueTLSCert(
 	caCert *bifrost.Certificate,
 	caKey, serverKey *bifrost.PrivateKey,
 ) (*bifrost.Certificate, error) {
-	gauntlet := func(_ *bifrost.CertificateRequest) (*x509.Certificate, error) {
+	gauntlet := func(_ context.Context, _ *bifrost.CertificateRequest) (*x509.Certificate, error) {
 		// Return a server certificate template that can be used for TLS.
 		return &x509.Certificate{
 			KeyUsage:              x509.KeyUsageDigitalSignature | x509.KeyUsageKeyEncipherment,

--- a/errors.go
+++ b/errors.go
@@ -7,9 +7,12 @@ var (
 	// ErrCertificateInvalid is returned when an invalid certificate is parsed.
 	ErrCertificateInvalid = errors.New("bifrost: certificate invalid")
 
-	// ErrCertificateRequestDenied is returned when a certificate request is denied by the CA Gauntlet.
-	ErrCertificateRequestDenied = errors.New("bifrost: certificate request denied")
+	// ErrRequestDenied is returned when a certificate request is denied by the CA Gauntlet.
+	ErrRequestDenied = errors.New("bifrost: certificate request denied")
 
-	// ErrCertificateRequestInvalid is returned when an invalid certificate request is parsed.
-	ErrCertificateRequestInvalid = errors.New("bifrost: certificate request invalid")
+	// ErrRequestInvalid is returned when an invalid certificate request is parsed.
+	ErrRequestInvalid = errors.New("bifrost: certificate request invalid")
+
+	// ErrRequestAborted is returned when the CA Gauntlet function times out or panics.
+	ErrRequestAborted = errors.New("bifrost: certificate request aborted")
 )

--- a/example_requestcert_test.go
+++ b/example_requestcert_test.go
@@ -22,11 +22,11 @@ func ExampleRequestCertificate() {
 	}
 
 	cert, err := RequestCertificate(ctx, "https://bifrost-ca", exampleNS, key)
-	if errors.Is(err, ErrCertificateRequestInvalid) {
+	if errors.Is(err, ErrRequestInvalid) {
 		// This error is returned when the wrong namespace is used in the CSR,
 		// or if the CSR is invalid.
 		fmt.Println("namespace mismatch or invalid csr")
-	} else if errors.Is(err, ErrCertificateRequestDenied) {
+	} else if errors.Is(err, ErrRequestDenied) {
 		// This error is returned when the request is denied by the CA gauntlet function.
 		fmt.Println("csr denied")
 	}

--- a/requestcert.go
+++ b/requestcert.go
@@ -54,9 +54,11 @@ func RequestCertificate(
 	switch resp.StatusCode {
 	case http.StatusOK:
 	case http.StatusBadRequest:
-		return nil, fmt.Errorf("%w, response: %s", ErrCertificateRequestInvalid, body)
+		return nil, fmt.Errorf("%w, response: %s", ErrRequestInvalid, body)
 	case http.StatusForbidden:
-		return nil, fmt.Errorf("%w, response: %s", ErrCertificateRequestDenied, body)
+		return nil, fmt.Errorf("%w, response: %s", ErrRequestDenied, body)
+	case http.StatusServiceUnavailable:
+		return nil, fmt.Errorf("%w, response: %s", ErrRequestAborted, body)
 	default:
 		return nil, fmt.Errorf(
 			"bifrost: unexpected response status: %s, body: %s",

--- a/tinyca/ca.go
+++ b/tinyca/ca.go
@@ -33,14 +33,14 @@ import (
 // CA is a simple Certificate Authority.
 // The CA issues client certificates signed by a root certificate and private key.
 type CA struct {
-	cert     *bifrost.Certificate
-	key      *bifrost.PrivateKey
-	gauntlet Gauntlet
+	cert *bifrost.Certificate
+	key  *bifrost.PrivateKey
+	gh   *gauntletHolder
 
 	// metrics
-	issuedTotal      *metrics.Counter
-	requestsTotal    *metrics.Counter
-	requestsDuration *metrics.Histogram
+	requests      *metrics.Counter
+	issuedTotal   *metrics.Counter
+	issueDuration *metrics.Histogram
 }
 
 // New returns a new Certificate Authority.
@@ -55,29 +55,21 @@ func New(
 		return nil, fmt.Errorf("bifrost: root certificate is not a valid CA")
 	}
 
-	if gauntlet == nil {
-		gauntlet = func(csr *bifrost.CertificateRequest) (*x509.Certificate, error) {
-			return nil, nil
-		}
+	reqs := bfMetricName("requests_total", cert.Namespace)
+	issued := bfMetricName("issued_certs_total", cert.Namespace)
+	issueDuration := bfMetricName("issue_duration_seconds", cert.Namespace)
+
+	ca := CA{
+		cert: cert,
+		key:  key,
+		gh:   newGauntletHolder(gauntlet, cert.Namespace),
+
+		requests:      bifrost.StatsForNerds.GetOrCreateCounter(reqs),
+		issuedTotal:   bifrost.StatsForNerds.GetOrCreateCounter(issued),
+		issueDuration: bifrost.StatsForNerds.GetOrCreateHistogram(issueDuration),
 	}
 
-	issued := bfMetricName("issued_certs_total", cert.Namespace)
-	reqsTotal := bfMetricName("requests_total", cert.Namespace)
-	reqsDur := bfMetricName("requests_duration_seconds", cert.Namespace)
-
-	return &CA{
-		cert:     cert,
-		key:      key,
-		gauntlet: gauntlet,
-
-		issuedTotal:      bifrost.StatsForNerds.GetOrCreateCounter(issued),
-		requestsTotal:    bifrost.StatsForNerds.GetOrCreateCounter(reqsTotal),
-		requestsDuration: bifrost.StatsForNerds.GetOrCreateHistogram(reqsDur),
-	}, nil
-}
-
-func bfMetricName(name string, ns uuid.UUID) string {
-	return fmt.Sprintf(`bifrost_ca_%s{ns="%s"}`, name, ns)
+	return &ca, nil
 }
 
 // ServeHTTP issues a certificate if a valid certificate request is read from the request.
@@ -85,9 +77,8 @@ func bfMetricName(name string, ns uuid.UUID) string {
 // Requests carrying a content-type of "text/plain" should have a PEM encoded certificate request.
 // Requests carrying a content-type of "application/octet-stream" should submit the ASN.1 DER
 // encoded form instead.
-func (ca CA) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	ca.requestsTotal.Inc()
-	startTime := time.Now()
+func (ca *CA) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	ca.requests.Inc()
 
 	nb := r.URL.Query().Get("not-before")
 	na := r.URL.Query().Get("not-after")
@@ -129,10 +120,12 @@ func (ca CA) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		statusCode := http.StatusInternalServerError
 
 		switch {
-		case errors.Is(err, bifrost.ErrCertificateRequestInvalid):
+		case errors.Is(err, bifrost.ErrRequestInvalid):
 			statusCode = http.StatusBadRequest
-		case errors.Is(err, bifrost.ErrCertificateRequestDenied):
+		case errors.Is(err, bifrost.ErrRequestDenied):
 			statusCode = http.StatusForbidden
+		case errors.Is(err, bifrost.ErrRequestAborted):
+			statusCode = http.StatusServiceUnavailable
 		}
 
 		writeHTTPError(ctx, w, err.Error(), statusCode)
@@ -171,34 +164,31 @@ func (ca CA) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		slog.ErrorContext(ctx, "error writing certificate response", "err", err)
 	}
-
-	ca.requestsDuration.Update(time.Since(startTime).Seconds())
 }
 
 // IssueCertificate issues a client certificate for a valid certificate request parsed from asn1CSR.
-func (ca CA) IssueCertificate(asn1CSR []byte, notBefore, notAfter time.Time) ([]byte, error) {
+func (ca *CA) IssueCertificate(asn1CSR []byte, notBefore, notAfter time.Time) ([]byte, error) {
+	issueStart := time.Now()
+
 	csr, err := bifrost.ParseCertificateRequest(asn1CSR)
 	if err != nil {
 		return nil, err
 	}
 
 	if csr.Namespace != ca.cert.Namespace {
-		return nil, fmt.Errorf("%w, namespace mismatch", bifrost.ErrCertificateRequestInvalid)
+		return nil, fmt.Errorf("%w, namespace mismatch", bifrost.ErrRequestInvalid)
 	}
 
 	if notBefore.IsZero() || notAfter.IsZero() || notAfter.Before(notBefore) {
 		return nil, fmt.Errorf(
 			"%w, invalid validity period",
-			bifrost.ErrCertificateRequestInvalid,
+			bifrost.ErrRequestInvalid,
 		)
 	}
 
-	template, err := ca.gauntlet(csr)
+	template, err := ca.gh.throw(csr)
 	if err != nil {
-		return nil, fmt.Errorf("%w, %s", bifrost.ErrCertificateRequestDenied, err)
-	}
-	if template == nil {
-		template = TLSClientCertTemplate()
+		return nil, err
 	}
 
 	template.NotBefore = notBefore
@@ -233,7 +223,9 @@ func (ca CA) IssueCertificate(asn1CSR []byte, notBefore, notAfter time.Time) ([]
 		return nil, err
 	}
 
+	ca.issueDuration.UpdateDuration(issueStart)
 	ca.issuedTotal.Inc()
+
 	return certBytes, nil
 }
 
@@ -258,4 +250,8 @@ func readCsr(contentType string, body []byte) ([]byte, error) {
 func writeHTTPError(ctx context.Context, w http.ResponseWriter, msg string, statusCode int) {
 	slog.ErrorContext(ctx, msg, "statusCode", statusCode)
 	http.Error(w, msg, statusCode)
+}
+
+func bfMetricName(name string, ns uuid.UUID) string {
+	return fmt.Sprintf(`bifrost_ca_%s{ns="%s"}`, name, ns)
 }

--- a/tinyca/gauntlet.go
+++ b/tinyca/gauntlet.go
@@ -1,0 +1,87 @@
+package tinyca
+
+import (
+	"context"
+	"crypto/x509"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/RealImage/bifrost"
+	"github.com/VictoriaMetrics/metrics"
+	"github.com/google/uuid"
+)
+
+type gauntletHolder struct {
+	Gauntlet
+
+	// metrics
+	denied   *metrics.Counter
+	aborted  *metrics.Counter
+	duration *metrics.Histogram
+}
+
+func newGauntletHolder(g Gauntlet, ns uuid.UUID) *gauntletHolder {
+	if g == nil {
+		return &gauntletHolder{}
+	}
+
+	denied := bfMetricName("gauntlet_denied_total", ns)
+	aborted := bfMetricName("gauntlet_aborted_total", ns)
+	duration := bfMetricName("gauntlet_duration_seconds", ns)
+
+	return &gauntletHolder{
+		Gauntlet: g,
+
+		denied:   bifrost.StatsForNerds.GetOrCreateCounter(denied),
+		aborted:  bifrost.StatsForNerds.GetOrCreateCounter(aborted),
+		duration: bifrost.StatsForNerds.GetOrCreateHistogram(duration),
+	}
+}
+
+func (gh *gauntletHolder) throw(csr *bifrost.CertificateRequest) (*x509.Certificate, error) {
+	if gh.Gauntlet == nil {
+		return TLSClientCertTemplate(), nil
+	}
+
+	ctx, cancel := context.WithCancelCause(context.Background())
+	defer cancel(nil)
+
+	timer := time.NewTimer(GauntletTimeout)
+	go func() {
+		<-timer.C
+		cancel(fmt.Errorf("%w, gauntlet timed out", bifrost.ErrRequestAborted))
+	}()
+
+	result := make(chan *x509.Certificate, 1)
+	go func() {
+		defer close(result)
+
+		start := time.Now()
+		template, err := gh.Gauntlet(ctx, csr)
+		gh.duration.UpdateDuration(start)
+
+		if err != nil {
+			cancel(fmt.Errorf("%w, %s", bifrost.ErrRequestDenied, err))
+		} else {
+			if template == nil {
+				template = TLSClientCertTemplate()
+			}
+			result <- template
+		}
+	}()
+
+	select {
+	case <-ctx.Done():
+		err := context.Cause(ctx)
+		if errors.Is(err, bifrost.ErrRequestAborted) {
+			gh.aborted.Inc()
+		}
+		if errors.Is(err, bifrost.ErrRequestDenied) {
+			gh.denied.Inc()
+		}
+		return nil, err
+	case tmpl := <-result:
+		return tmpl, nil
+	}
+}

--- a/tinyca/templates.go
+++ b/tinyca/templates.go
@@ -1,20 +1,27 @@
 package tinyca
 
 import (
+	"context"
 	"crypto/rand"
 	"crypto/x509"
 	"crypto/x509/pkix"
 	"fmt"
 	"math"
 	"math/big"
+	"time"
 
 	"github.com/RealImage/bifrost"
 	"github.com/google/uuid"
 )
 
+// GauntletTimeout is the maximum time the CA Gauntlet function is allowed to run.
+const GauntletTimeout = 100 * time.Millisecond
+
 // Gauntlet is the signature for a function that validates a certificate request.
 // If the second return value is non-nil, then the certificate request is denied.
 // If the first return value is nil, the default template TLSClientCertTemplate will be used.
+// If the function exceeds GauntletTimeout, ctx will be cancelled and the
+// request will be denied with an error.
 // The template will be used to issue a client certificate.
 // Consult the x509 package for the full list of fields that can be set.
 // tinyca will overwrite the following template fields:
@@ -27,7 +34,7 @@ import (
 //   - BasicConstraintsValid
 //
 // If SerialNumber is nil, a random value will be generated.
-type Gauntlet func(csr *bifrost.CertificateRequest) (tmpl *x509.Certificate, err error)
+type Gauntlet func(ctx context.Context, csr *bifrost.CertificateRequest) (tmpl *x509.Certificate, err error)
 
 // TLSClientCertTemplate returns a new x509.Certificate template for a client certificate.
 func TLSClientCertTemplate() *x509.Certificate {


### PR DESCRIPTION
Gauntlet func takes a context as the first arg.
The context is cancelled after tinyca.GauntletTimeout. The gauntlet result is ignored after tinyca.GauntletTimeout. A 503 error is returned to the client in this case.