### PR TITLE
feat: CA creates a http.ServeMux with its routes

### DIFF
--- a/tinyca/ca.go
+++ b/tinyca/ca.go
@@ -174,6 +174,19 @@ func (ca *CA) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
+// ServeMux returns an http.ServeMux with the CA's HTTP handler registered at "POST /issue".
+// The ServeMux also provides a "GET /namespace" endpoint that returns the namespace of the CA.
+func (ca *CA) ServeMux() *http.ServeMux {
+	mux := http.NewServeMux()
+	mux.Handle("POST /issue", ca)
+	nss := ca.cert.Namespace.String()
+	mux.HandleFunc("GET /namespace", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/plain")
+		fmt.Fprintln(w, nss)
+	})
+	return mux
+}
+
 // IssueCertificate issues a client certificate for a valid certificate request parsed from asn1CSR.
 func (ca *CA) IssueCertificate(asn1CSR []byte, notBefore, notAfter time.Time) ([]byte, error) {
 	issueStart := time.Now()


### PR DESCRIPTION
CA creates a "standard" mux which responds to "POST /issue" with CA.ServeHTTP.
It also responds to "GET /namespace" with a plain-text UUID namespace string.