### PR TITLE
feat: Use a global logger

### DIFF
--- a/asgard/hofund.go
+++ b/asgard/hofund.go
@@ -2,7 +2,6 @@ package asgard
 
 import (
 	"encoding/pem"
-	"log/slog"
 	"net/http"
 	"net/url"
 
@@ -29,13 +28,14 @@ func Hofund(h HeaderName, ns uuid.UUID) func(http.Handler) http.Handler {
 
 			cert, err := bifrost.NewCertificate(r.TLS.PeerCertificates[0])
 			if err != nil {
-				slog.ErrorContext(ctx, "error validating client certificate", "error", err)
+				bifrost.Logger().
+					ErrorContext(ctx, "error validating client certificate", "error", err)
 				http.Error(w, "invalid client certificate", http.StatusUnauthorized)
 				return
 			}
 
 			if cert.Namespace != ns {
-				slog.ErrorContext(
+				bifrost.Logger().ErrorContext(
 					ctx, "client certificate namespace mismatch",
 					"expected", ns,
 					"actual", cert.Namespace,

--- a/bifrost.go
+++ b/bifrost.go
@@ -1,0 +1,38 @@
+// Package bifrost contains an API client for the Bifrost CA service.
+package bifrost
+
+import (
+	"context"
+	"log/slog"
+	"sync/atomic"
+)
+
+var (
+	// LogLevel is the log level used by the bifrost logger.
+	LogLevel = new(slog.LevelVar)
+
+	logger atomic.Pointer[slog.Logger]
+)
+
+// Logger returns the global Bifrost logger.
+func Logger() *slog.Logger {
+	return logger.Load()
+}
+
+// SetLogger sets the [*slog.Logger] used by bifrost.
+// The default handler disables logging.
+func SetLogger(l *slog.Logger) {
+	logger.Store(l)
+}
+
+func init() {
+	SetLogger(slog.New(discardHandler{}))
+}
+
+// discardHandler is an [slog.Handler] which is always disabled and therefore logs nothing.
+type discardHandler struct{}
+
+func (discardHandler) Enabled(context.Context, slog.Level) bool  { return false }
+func (discardHandler) Handle(context.Context, slog.Record) error { return nil }
+func (d discardHandler) WithAttrs([]slog.Attr) slog.Handler      { return d }
+func (d discardHandler) WithGroup(string) slog.Handler           { return d }

--- a/client.go
+++ b/client.go
@@ -54,7 +54,10 @@ func (cr *certRefresher) GetClientCertificate(
 	}
 
 	// If the certificate is nil or is going to expire soon, request a new one.
-	if cert := cr.cert.Load(); cert == nil || cert.NotAfter.Before(time.Now().Add(-time.Minute*10)) {
+	if cert := cr.cert.Load(); cert == nil ||
+		cert.NotAfter.Before(time.Now().Add(-time.Minute*10)) {
+		Logger().DebugContext(ctx, "refreshing client certificate")
+
 		cert, err := RequestCertificate(ctx, cr.url, cr.privkey)
 		if err != nil {
 			return nil, err
@@ -66,6 +69,7 @@ func (cr *certRefresher) GetClientCertificate(
 				break
 			}
 		}
+		Logger().InfoContext(ctx, "got new client certificate")
 	}
 
 	tlsCert := X509ToTLSCertificate(cr.cert.Load().Certificate, cr.privkey.PrivateKey)

--- a/cmd/bf/id.go
+++ b/cmd/bf/id.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"log/slog"
 	"os"
 
 	"github.com/RealImage/bifrost"
@@ -36,7 +35,7 @@ var idCmd = &cli.Command{
 
 		id, err := bifrost.ParseIdentity(data)
 		if err != nil {
-			slog.ErrorContext(ctx, "error parsing id file", "error", err)
+			bifrost.Logger().ErrorContext(ctx, "error parsing id file", "error", err)
 			return cli.Exit("Error parsing file", 1)
 		}
 
@@ -46,7 +45,8 @@ var idCmd = &cli.Command{
 
 		// Either we got a namespace from the file or the namespace flag is set
 		if id.Namespace != uuid.Nil && namespace != uuid.Nil && id.Namespace != namespace {
-			slog.ErrorContext(ctx, "namespace mismatch", "file", id.Namespace, "flag", namespace)
+			bifrost.Logger().
+				ErrorContext(ctx, "namespace mismatch", "file", id.Namespace, "flag", namespace)
 			return cli.Exit("Namespace mismatch", 1)
 		}
 
@@ -54,7 +54,7 @@ var idCmd = &cli.Command{
 			id.Namespace = namespace
 		}
 
-		slog.Debug("using", "namespace", id.Namespace)
+		bifrost.Logger().Debug("using", "namespace", id.Namespace)
 		fmt.Println(id.UUID())
 
 		return nil

--- a/cmd/bf/main.go
+++ b/cmd/bf/main.go
@@ -5,15 +5,19 @@ import (
 	"log/slog"
 	"os"
 
+	"github.com/RealImage/bifrost"
 	"github.com/urfave/cli/v3"
 )
 
 var version = "devel"
 
 func main() {
-	logLevel := new(slog.LevelVar)
-	hdlr := slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: logLevel})
-	slog.SetDefault(slog.New(hdlr))
+	logger := slog.New(
+		slog.NewJSONHandler(os.Stderr, &slog.HandlerOptions{Level: bifrost.LogLevel}),
+	)
+
+	slog.SetDefault(logger)
+	bifrost.SetLogger(logger)
 
 	cli := &cli.Command{
 		Name:    "bifrost",
@@ -27,7 +31,7 @@ func main() {
 				Sources: cli.EnvVars("LOG_LEVEL"),
 				Value:   slog.LevelInfo.String(),
 				Action: func(_ context.Context, _ *cli.Command, level string) error {
-					return logLevel.UnmarshalText([]byte(level))
+					return bifrost.LogLevel.UnmarshalText([]byte(level))
 				},
 			},
 		},

--- a/cmd/bf/new.go
+++ b/cmd/bf/new.go
@@ -7,7 +7,6 @@ import (
 	"crypto/x509/pkix"
 	"encoding/pem"
 	"fmt"
-	"log/slog"
 
 	"github.com/RealImage/bifrost"
 	"github.com/RealImage/bifrost/cafiles"
@@ -35,7 +34,8 @@ var newCmd = &cli.Command{
 				}
 				defer func() {
 					if err := cls(); err != nil {
-						slog.ErrorContext(ctx, "error closing output writer", "error", err)
+						bifrost.Logger().
+							ErrorContext(ctx, "error closing output writer", "error", err)
 					}
 				}()
 
@@ -67,7 +67,8 @@ var newCmd = &cli.Command{
 				}
 				defer func() {
 					if err := cls(); err != nil {
-						slog.ErrorContext(ctx, "error closing output writer", "error", err)
+						bifrost.Logger().
+							ErrorContext(ctx, "error closing output writer", "error", err)
 					}
 				}()
 
@@ -110,7 +111,8 @@ var newCmd = &cli.Command{
 				}
 				defer func() {
 					if err := cls(); err != nil {
-						slog.ErrorContext(ctx, "error closing output writer", "error", err)
+						bifrost.Logger().
+							ErrorContext(ctx, "error closing output writer", "error", err)
 					}
 				}()
 
@@ -173,7 +175,8 @@ var newCmd = &cli.Command{
 				}
 				defer func() {
 					if err := cls(); err != nil {
-						slog.ErrorContext(ctx, "error closing output writer", "error", err)
+						bifrost.Logger().
+							ErrorContext(ctx, "error closing output writer", "error", err)
 					}
 				}()
 

--- a/cmd/bf/request.go
+++ b/cmd/bf/request.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/pem"
 	"fmt"
-	"log/slog"
 
 	"github.com/RealImage/bifrost"
 	"github.com/RealImage/bifrost/cafiles"
@@ -33,20 +32,20 @@ var requestCmd = &cli.Command{
 		if namespace == uuid.Nil {
 			var err error
 			if namespace, err = bifrost.GetNamespace(ctx, caUrl); err != nil {
-				slog.ErrorContext(ctx, "error fetching namespace", "error", err)
+				bifrost.Logger().ErrorContext(ctx, "error fetching namespace", "error", err)
 				return cli.Exit("Namespace not provided and could not be fetched", 1)
 			}
 		}
 
 		key, err := cafiles.GetPrivateKey(ctx, clientPrivKeyUri)
 		if err != nil {
-			slog.ErrorContext(ctx, "error reading private key", "error", err)
+			bifrost.Logger().ErrorContext(ctx, "error reading private key", "error", err)
 			return cli.Exit("Failed to read private key", 1)
 		}
 
 		cert, err := bifrost.RequestCertificate(ctx, caUrl, key)
 		if err != nil {
-			slog.ErrorContext(ctx, "error requesting certificate", "error", err)
+			bifrost.Logger().ErrorContext(ctx, "error requesting certificate", "error", err)
 			return cli.Exit("Failed to request certificate", 1)
 		}
 
@@ -57,17 +56,17 @@ var requestCmd = &cli.Command{
 
 		out, cls, err := getOutputWriter()
 		if err != nil {
-			slog.ErrorContext(ctx, "error opening output file", "error", err)
+			bifrost.Logger().ErrorContext(ctx, "error opening output file", "error", err)
 			return cli.Exit("Failed to open output file", 1)
 		}
 		defer func() {
 			if err := cls(); err != nil {
-				slog.ErrorContext(ctx, "error closing output writer", "error", err)
+				bifrost.Logger().ErrorContext(ctx, "error closing output writer", "error", err)
 			}
 		}()
 
 		if err := pem.Encode(out, block); err != nil {
-			slog.ErrorContext(ctx, "error writing certificate", "error", err)
+			bifrost.Logger().ErrorContext(ctx, "error writing certificate", "error", err)
 			return cli.Exit("Failed to write certificate", 1)
 		}
 

--- a/doc.go
+++ b/doc.go
@@ -1,2 +1,0 @@
-// Package bifrost contains an API client for the Bifrost CA service.
-package bifrost

--- a/internal/webapp/requestlog.go
+++ b/internal/webapp/requestlog.go
@@ -5,6 +5,7 @@ import (
 	"log/slog"
 	"net/http"
 
+	"github.com/RealImage/bifrost"
 	"github.com/felixge/httpsnoop"
 )
 
@@ -21,7 +22,7 @@ func RequestLogger(h http.Handler) http.Handler {
 			level = slog.LevelError
 		}
 
-		slog.LogAttrs(
+		bifrost.Logger().LogAttrs(
 			r.Context(),
 			level,
 			fmt.Sprintf("%s %s", r.Method, r.RequestURI),

--- a/tinyca/ca.go
+++ b/tinyca/ca.go
@@ -17,13 +17,13 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"log/slog"
 	"math"
 	"math/big"
 	"net/http"
 	"time"
 
 	"github.com/RealImage/bifrost"
+
 	"github.com/RealImage/bifrost/internal/webapp"
 	"github.com/VictoriaMetrics/metrics"
 	"github.com/google/uuid"
@@ -163,7 +163,7 @@ func (ca *CA) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if err != nil {
-		slog.ErrorContext(ctx, "error writing certificate response", "err", err)
+		bifrost.Logger().ErrorContext(ctx, "error writing certificate response", "err", err)
 	}
 }
 
@@ -177,7 +177,7 @@ func (ca *CA) AddRoutes(mux *http.ServeMux, metrics bool) {
 	mux.Handle("POST /issue", ca)
 
 	if metrics {
-		slog.Info("metrics enabled")
+		bifrost.Logger().Info("metrics enabled")
 		mux.HandleFunc("GET /metrics", func(w http.ResponseWriter, r *http.Request) {
 			bifrost.StatsForNerds.WritePrometheus(w)
 		})
@@ -244,7 +244,7 @@ func (ca *CA) IssueCertificate(asn1CSR []byte, notBefore, notAfter time.Time) ([
 	ca.issueSize.Update(float64(len(certBytes)))
 	ca.issuedTotal.Inc()
 
-	slog.Debug("certificate issued", "to", csr.ID, "duration", time.Since(issueStart))
+	bifrost.Logger().Debug("certificate issued", "to", csr.ID, "duration", time.Since(issueStart))
 
 	return certBytes, nil
 }
@@ -289,13 +289,13 @@ func getNamespaceHandler(ns uuid.UUID) http.Handler {
 		}
 
 		if err != nil {
-			slog.Error("error writing namespace", "err", err)
+			bifrost.Logger().Error("error writing namespace", "err", err)
 		}
 	})
 }
 
 func writeHTTPError(ctx context.Context, w http.ResponseWriter, msg string, statusCode int) {
-	slog.ErrorContext(ctx, msg, "statusCode", statusCode)
+	bifrost.Logger().ErrorContext(ctx, msg, "statusCode", statusCode)
 	http.Error(w, msg, statusCode)
 }
 

--- a/tinyca/gauntlet.go
+++ b/tinyca/gauntlet.go
@@ -5,7 +5,6 @@ import (
 	"crypto/x509"
 	"errors"
 	"fmt"
-	"log/slog"
 	"plugin"
 	"strings"
 	"sync"
@@ -123,7 +122,7 @@ func (gh *gauntletThrower) throw(csr *bifrost.CertificateRequest) (*x509.Certifi
 		defer close(result)
 		defer func() {
 			if r := recover(); r != nil {
-				slog.ErrorContext(ctx, "gauntlet panic", "recovered", r)
+				bifrost.Logger().ErrorContext(ctx, "gauntlet panic", "recovered", r)
 				cancel(fmt.Errorf("%w, gauntlet panic('%v')", bifrost.ErrRequestAborted, r))
 			}
 		}()
@@ -131,7 +130,7 @@ func (gh *gauntletThrower) throw(csr *bifrost.CertificateRequest) (*x509.Certifi
 		start := time.Now()
 		template, err := gh.Gauntlet(ctx, csr)
 		gh.duration.UpdateDuration(start)
-		slog.DebugContext(ctx, "threw gauntlet", "duration", time.Since(start))
+		bifrost.Logger().DebugContext(ctx, "threw gauntlet", "duration", time.Since(start))
 
 		if err != nil {
 			cancel(fmt.Errorf("%w, %s", bifrost.ErrRequestDenied, err))


### PR DESCRIPTION
Use a global logger for all library and application logs. Users can set this log to customise log output.